### PR TITLE
Flatten namespace packages

### DIFF
--- a/dev/fit.py
+++ b/dev/fit.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 import numpy as np
 import sherpa.ui as ui
 from mpi4py import MPI
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 import pyyaks.context as pyc
 
 import clogging   # get rid of this or something

--- a/dev/worker.py
+++ b/dev/worker.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     matplotlib.use('Agg')
 
 import numpy as np
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 from mpi4py import MPI
 import pyyaks.context as pyc
 

--- a/examples/dpa/plot_dpa_resid.py
+++ b/examples/dpa/plot_dpa_resid.py
@@ -2,7 +2,7 @@
 import xija
 import numpy as np
 import matplotlib.pyplot as plt
-from Ska.Matplotlib import pointpair
+from ska_matplotlib import pointpair
 
 start = '2010:001'
 stop = '2011:345'

--- a/models/acisfp/calc_model.py
+++ b/models/acisfp/calc_model.py
@@ -8,8 +8,8 @@ values.
 """
 
 import xija
-import Ska.engarchive.fetch_eng as fetch_eng
-from Ska.Matplotlib import plot_cxctime
+import cheta.fetch_eng as fetch_eng
+from ska_matplotlib import plot_cxctime
 
 start = '2012:001'
 stop = '2012:005'

--- a/models/psmc/make_psmc_from_twodof.py
+++ b/models/psmc/make_psmc_from_twodof.py
@@ -2,8 +2,8 @@
 import xija
 import numpy as np
 import asciitable
-from Chandra.Time import DateTime
-from Ska.Matplotlib import plot_cxctime
+from chandra_time import DateTime
+from ska_matplotlib import plot_cxctime
 
 pars = dict(acis150 =  28.029,
             acis50  =  54.192,

--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -3,7 +3,7 @@ import numpy as np
 import six
 
 try:
-    from Ska.Matplotlib import cxctime2plotdate, plot_cxctime
+    from ska_matplotlib import cxctime2plotdate, plot_cxctime
 except ImportError:
     pass
 

--- a/xija/component/deprecated.py
+++ b/xija/component/deprecated.py
@@ -7,7 +7,7 @@ from xija.component.base import ModelComponent
 from xija.component.heat import PrecomputedHeatPower, SolarHeat
 
 try:
-    from Ska.Matplotlib import plot_cxctime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 

--- a/xija/component/experimental.py
+++ b/xija/component/experimental.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 try:
-    from Ska.Matplotlib import plot_cxctime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 

--- a/xija/component/heat/earth.py
+++ b/xija/component/heat/earth.py
@@ -16,8 +16,8 @@ from xija.component.base import ModelComponent
 from xija.component.heat.base import PrecomputedHeatPower
 
 try:
-    from Chandra.Time import DateTime
-    from Ska.Matplotlib import plot_cxctime
+    from chandra_time import DateTime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 
@@ -100,7 +100,7 @@ class EarthHeat(PrecomputedHeatPower):
         hp_idxs = healpix.lonlat_to_healpix(lons * u.rad, lats * u.rad)
 
         # Linearly interpolate distances for appropriate healpix pixels.
-        # Code borrowed a bit from Ska.Numpy.Numpy._interpolate_vectorized.
+        # Code borrowed a bit from ska_numpy.Numpy._interpolate_vectorized.
         xin = self.log_earth_vis_dists
         xout = np.log(dists)
         idxs = np.searchsorted(xin, xout)

--- a/xija/component/heat/electronics.py
+++ b/xija/component/heat/electronics.py
@@ -9,7 +9,7 @@ from xija.component.base import TelemData
 from xija.component.heat.base import PrecomputedHeatPower
 
 try:
-    from Ska.Matplotlib import plot_cxctime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 

--- a/xija/component/heat/generic.py
+++ b/xija/component/heat/generic.py
@@ -5,8 +5,8 @@ import numpy as np
 from xija.component.heat.base import ActiveHeatPower, PrecomputedHeatPower
 
 try:
-    from Chandra.Time import DateTime
-    from Ska.Matplotlib import plot_cxctime
+    from chandra_time import DateTime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 

--- a/xija/component/heat/solar.py
+++ b/xija/component/heat/solar.py
@@ -4,9 +4,9 @@ import numpy as np
 import scipy.interpolate
 
 try:
-    import Ska.Numpy
-    from Chandra.Time import DateTime
-    from Ska.Matplotlib import plot_cxctime
+    import ska_numpy
+    from chandra_time import DateTime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 
@@ -666,7 +666,7 @@ class SimZDepSolarHeat(PrecomputedHeatPower):
         dPs = self.parvals[
             self.n_instr * self.n_p : (self.n_instr * self.n_p + self.n_dp)
         ]
-        dP_vals = Ska.Numpy.interpolate(dPs, self.dP_pitches, self.pitches)
+        dP_vals = ska_numpy.interpolate(dPs, self.dP_pitches, self.pitches)
         d_heat = (
             dP_vals * self.var_func(self.t_days, self.tau)
             + self.ampl * np.cos(self.t_phase)
@@ -674,7 +674,7 @@ class SimZDepSolarHeat(PrecomputedHeatPower):
 
         for i in range(self.n_instr):
             P_vals = self.parvals[i * self.n_p : (i + 1) * self.n_p]
-            heat = Ska.Numpy.interpolate(P_vals, self.P_pitches, self.pitches)
+            heat = ska_numpy.interpolate(P_vals, self.P_pitches, self.pitches)
             heats.append(heat + d_heat)
 
         self.heats = np.vstack(heats)

--- a/xija/component/mask.py
+++ b/xija/component/mask.py
@@ -4,7 +4,7 @@ import operator
 import numpy as np
 
 try:
-    from Ska.Matplotlib import plot_cxctime
+    from ska_matplotlib import plot_cxctime
 except ImportError:
     pass
 

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import List
 
-from Ska.File import get_globfiles
+from ska_file import get_globfiles
 from ska_helpers import chandra_models
 from ska_helpers.paths import chandra_models_repo_path, xija_models_path
 

--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -864,7 +864,7 @@ class MainWindow:
     # This is a callback function. The data arguments are ignored
     # in this example. More on callbacks below.
     def __init__(self, model, fit_worker, model_file):
-        import Ska.tdb
+        import ska_tdb
 
         self.model = model
 
@@ -878,7 +878,7 @@ class MainWindow:
                 ):
                     self.hist_msids.append(k)
                 try:
-                    Ska.tdb.msids[v.msid]
+                    ska_tdb.msids[v.msid]
                 except KeyError:
                     pass
                 else:

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -8,7 +8,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 from PyQt5 import QtCore, QtWidgets
-from Ska.Matplotlib import cxctime2plotdate, plot_cxctime
+from ska_matplotlib import cxctime2plotdate, plot_cxctime
 
 from xija.limits import get_limit_color
 

--- a/xija/model.py
+++ b/xija/model.py
@@ -16,12 +16,12 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 import pyyaks.context as pyc
-import Ska.DBI
-import Ska.Numpy
+import ska_dbi
+import ska_numpy
 from astropy.io import ascii
 
 # Optional packages for model fitting or use on HEAD LAN
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 from cxotime import date2secs
 
 from . import clogging, component, tmal
@@ -366,18 +366,18 @@ class XijaModel(object):
         datestop = DateTime(self.tstop + tpad).date
         logger.info("Fetching msid: %s over %s to %s" % (msid, datestart, datestop))
         try:
-            import Ska.engarchive.fetch_sci as fetch
+            import cheta.fetch_sci as fetch
 
             tlm = fetch.MSID(msid, datestart, datestop, stat="5min")
             tlm.filter_bad_times()
         except ImportError:
-            raise ValueError("Ska.engarchive.fetch not available")
+            raise ValueError("cheta.fetch not available")
         if tlm.times[0] > self.tstart or tlm.times[-1] < self.tstop:
             raise ValueError(
                 "Fetched telemetry does not span model start and "
                 "stop times for {}".format(msid)
             )
-        vals = Ska.Numpy.interpolate(
+        vals = ska_numpy.interpolate(
             getattr(tlm, attr), tlm.times, self.times, method=method
         )
         return vals
@@ -418,7 +418,7 @@ class XijaModel(object):
             )
 
         if times.ndim == 1:  # Data value specification
-            vals = Ska.Numpy.interpolate(data, times, self.times, method="nearest")
+            vals = ska_numpy.interpolate(data, times, self.times, method="nearest")
         elif times.ndim == 2:  # State-value specification
             tstarts = times[0]
             tstops = times[1]

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -12,7 +12,7 @@ from xija import Eclipse, HeatSink, Node, Pitch, SolarHeat, ThermalModel, __vers
 from xija.get_model_spec import get_xija_model_names, get_xija_model_spec
 
 try:
-    import Ska.Matplotlib  # noqa
+    import ska_matplotlib  # noqa
 
     HAS_PLOTDATE = True
 except ImportError:


### PR DESCRIPTION
This is the pathfinder for converting all references to namespace packages[^1] in flight Ska packages[^2] to the equivalent flat name like `chandra_time` or `ska_file`.

[^1]: E.g. Chandra.Time or Ska.File
[^2]: packages that are included in `ska3-flight`